### PR TITLE
fix(budget): error wording

### DIFF
--- a/langs/fr_FR.json
+++ b/langs/fr_FR.json
@@ -359,7 +359,7 @@
     "conditions": "Conditions",
     "erase": "Effacer",
     "formErrors": {
-      "budgetMaxSupMandate": "Le budget max de votre mandat est de {{amount}}",
+      "budgetMaxSupMandate": "Le budget max de votre mandat est de",
       "budgetMinSupMax": "Le budget minimum doit être inférieur\n au budget maximum"
     },
     "hasNeedRenovation": "Avec présence de travaux",


### PR DESCRIPTION

<!-- diff_start -->
## fr_FR.json

### Modified
#### *propertiesPreferences.formErrors.budgetMaxSupMandate*
```diff
- Le budget max de votre mandat est de {{amount}}
+ Le budget max de votre mandat est de
```
<!-- diff_end -->