### PR TITLE
feat(app): handle max errors on pre and post mandat

### DIFF
--- a/langs/en_US.json
+++ b/langs/en_US.json
@@ -359,7 +359,8 @@
     "conditions": "Conditions",
     "erase": "Delete",
     "formErrors": {
-      "budgetMaxSupMandate": "The maximum budget for your mandate is ",
+      "budgetMaxSupPostMandate": "The maximum budget for your mandate is ",
+      "budgetMaxSupPreMandate": "The maximum budge is too high",
       "budgetMinSupMax": "The minimum budget must be less than\n the maximum budget"
     },
     "hasNeedRenovation": "With the presence of works",

--- a/langs/en_US.json
+++ b/langs/en_US.json
@@ -360,7 +360,7 @@
     "erase": "Delete",
     "formErrors": {
       "budgetMaxSupPostMandate": "The maximum budget for your mandate is ",
-      "budgetMaxSupPreMandate": "The maximum budge is too high",
+      "budgetMaxSupPreMandate": "The maximum budget is too high",
       "budgetMinSupMax": "The minimum budget must be less than\n the maximum budget"
     },
     "hasNeedRenovation": "With the presence of works",

--- a/langs/es_ES.json
+++ b/langs/es_ES.json
@@ -362,7 +362,8 @@
     "conditions": "Condiciones",
     "erase": "Borrar",
     "formErrors": {
-      "budgetMaxSupMandate": "El presupuesto máximo para su mandato es de {{amount}}",
+      "budgetMaxSupPostMandate": "El presupuesto máximo para su mandato es de ",
+      "budgetMaxSupPreMandate": "Budget máximo demasiado importante",
       "budgetMinSupMax": "El presupuesto mínimo debe ser inferior a\n el presupuesto máximo"
     },
     "hasNeedRenovation": "Con la presencia de obras",

--- a/langs/es_ES.json
+++ b/langs/es_ES.json
@@ -363,7 +363,7 @@
     "erase": "Borrar",
     "formErrors": {
       "budgetMaxSupPostMandate": "El presupuesto máximo para su mandato es de ",
-      "budgetMaxSupPreMandate": "Budget máximo demasiado importante",
+      "budgetMaxSupPreMandate": "El presupuesto máximo es demasiado importante",
       "budgetMinSupMax": "El presupuesto mínimo debe ser inferior a\n el presupuesto máximo"
     },
     "hasNeedRenovation": "Con la presencia de obras",

--- a/langs/fr_FR.json
+++ b/langs/fr_FR.json
@@ -365,7 +365,8 @@
     "conditions": "Conditions",
     "erase": "Effacer",
     "formErrors": {
-      "budgetMaxSupMandate": "Le budget max de votre mandat est de ",
+      "budgetMaxSupPostMandate": "Le budget max de votre mandat est de ",
+      "budgetMaxSupPreMandate": "Budget max trop important",
       "budgetMinSupMax": "Le budget minimum doit être inférieur\n au budget maximum"
     },
     "hasNeedRenovation": "Avec présence de travaux",


### PR DESCRIPTION

<!-- diff_start -->
## en_US.json

### Added
#### *propertiesPreferences.formErrors.budgetMaxSupPostMandate*
```diff
+ The maximum budget for your mandate is 
```
#### *propertiesPreferences.formErrors.budgetMaxSupPreMandate*
```diff
+ The maximum budge is too high
```

### Removed
#### *propertiesPreferences.formErrors.budgetMaxSupMandate*
```diff
- The maximum budget for your mandate is 
```
## es_ES.json

### Added
#### *propertiesPreferences.formErrors.budgetMaxSupPostMandate*
```diff
+ El presupuesto máximo para su mandato es de 
```
#### *propertiesPreferences.formErrors.budgetMaxSupPreMandate*
```diff
+ Budget máximo demasiado importante
```

### Removed
#### *propertiesPreferences.formErrors.budgetMaxSupMandate*
```diff
- El presupuesto máximo para su mandato es de {{amount}}
```
## fr_FR.json

### Added
#### *propertiesPreferences.formErrors.budgetMaxSupPostMandate*
```diff
+ Le budget max de votre mandat est de 
```
#### *propertiesPreferences.formErrors.budgetMaxSupPreMandate*
```diff
+ Budget max trop important
```

### Removed
#### *propertiesPreferences.formErrors.budgetMaxSupMandate*
```diff
- Le budget max de votre mandat est de 
```
![the secret gif](https://media.giphy.com/media/FVZoYkTx3cuVCkEavD/giphy.gif)
<!-- diff_end -->