### PR TITLE
feat(property-preview): add 'seen' translation

### DIFF
--- a/langs/en_US.json
+++ b/langs/en_US.json
@@ -509,8 +509,12 @@
     "title": "How the selection works"
   },
   "propertyPreview": {
-    "room": "{{count}} ch.",
-    "roomZero": "Studio"
+    "roomZero": "Studio",
+    "room": "{{count}} rooms",
+    "netReturn": "Net return",
+    "revaluationRate": "Revaluation",
+    "projectCost": "(Project cost)",
+    "seen": "Seen"
   },
   "propertyRenovation": {
     "DPE": {

--- a/langs/es_ES.json
+++ b/langs/es_ES.json
@@ -517,7 +517,8 @@
     "projectCost": "(Coste del proyecto)",
     "revaluationRate": "Revalorización",
     "room": "{{count}} ch.",
-    "roomZero": "Estudio"
+    "roomZero": "Estudio",
+    "seen": "Visto"
   },
   "propertyRenovation": {
     "DPE": {

--- a/langs/fr_FR.json
+++ b/langs/fr_FR.json
@@ -1028,6 +1028,7 @@
     "room": "{{count}} ch.",
     "netReturn": "Rendement net",
     "revaluationRate": "Prise de valeur",
-    "projectCost": "(Coût du projet)"
+    "projectCost": "(Coût du projet)",
+    "seen": "Vu"
   }
 }


### PR DESCRIPTION

<!-- diff_start -->
## en_US.json

### Added
#### *propertyPreview.netReturn*
```diff
+ Net return
```
#### *propertyPreview.revaluationRate*
```diff
+ Revaluation
```
#### *propertyPreview.projectCost*
```diff
+ (Project cost)
```
#### *propertyPreview.seen*
```diff
+ Seen
```

### Modified
#### *propertyPreview.room*
```diff
- {{count}} ch.
+ {{count}} rooms
```
## es_ES.json

### Added
#### *propertyPreview.seen*
```diff
+ Visto
```
## fr_FR.json

### Added
#### *propertyPreview.seen*
```diff
+ Vu
```
<!-- diff_end -->